### PR TITLE
Ignore implicit mount options

### DIFF
--- a/studip_fuse/__main__/cmd_util.py
+++ b/studip_fuse/__main__/cmd_util.py
@@ -79,7 +79,8 @@ def StoreNameValuePair(option_parser):
             ignored_values = []
             values = flatten(v.split(',') for v in values)
             for value in values:
-                if value in ["suid", "nosuid", "dev", "nodev", "ro"]:
+                if value in ["dev", "nodev", "exec", "noexec", "suid", "nosuid", "ro"]:
+                    # -o arguments set automatically from fstab that should be ignored
                     ignored_values.append(value)
                 elif value == "rw":
                     parser.error("Stud.IP FUSE only supports read-only mount")


### PR DESCRIPTION
mount automatically adds '-o noexec' when a mount has the 'user' option (as well as 'nodev' and 'nosuid'). Since studip-fuse doesn't produce any executable, device, or suid files, these options can (and should) be ignored.

Fixes #8.