### PR TITLE
log machine-readable status information

### DIFF
--- a/studip_fuse/__main__/__init__.py
+++ b/studip_fuse/__main__/__init__.py
@@ -11,7 +11,7 @@ import yaml
 
 from studip_fuse import __author__ as prog_author
 from studip_fuse.__main__.cmd_util import parse_args
-from studip_fuse.__main__.fs_driver import FixedFUSE
+from studip_fuse.__main__.fs_driver import FixedFUSE, log_status
 
 
 def excepthook(type, value, tb):
@@ -73,6 +73,9 @@ def configure_logging():
         if "file" in handlers and "filename" not in handlers["file"]:
             handlers["file"]["filename"] = os.path.join(dirs.user_data_dir, "studip-log.txt")
 
+        if "status" in handlers and "filename" not in handlers["status"]:
+            handlers["status"]["filename"] = os.path.join(dirs.user_data_dir, "studip-status.txt")
+
     logging.config.dictConfig(logging_config)
 
     sys.excepthook = excepthook
@@ -83,6 +86,7 @@ def configure_logging():
 
 
 def main():
+    args = None
     try:
         configure_logging()
 
@@ -115,6 +119,7 @@ def main():
         args.get_password = lambda: password  # wrap in lambda to prevent printing
 
         from fuse import FUSE, fuse_get_context
+        log_status("STARTING", args=args, level=logging.DEBUG)
         logging.debug("Starting FUSE driver to mount at %s (uid=%s, gid=%s, pid=%s, python pid=%s)", args.mount,
                       *fuse_get_context(), os.getpid())
         # This calls fork if args.foreground == False (https://bugs.python.org/issue21998)
@@ -124,6 +129,7 @@ def main():
     except:
         logging.error("main() function quit exceptionally", exc_info=True)
     finally:
+        log_status("TERMINATED", args=args, level=logging.DEBUG)
         logging.debug("Program terminated")
 
 

--- a/studip_fuse/__main__/fs_driver.py
+++ b/studip_fuse/__main__/fs_driver.py
@@ -26,6 +26,11 @@ log = logging.getLogger("studip_fuse.fs_driver")
 log_ops = logging.getLogger("studip_fuse.fs_driver.ops")
 
 
+def log_status(status, args=None, level=logging.INFO):
+    args = (status, *fuse_get_context(), os.getpid(), args.user if args else "?", args.mount if args else "?")
+    logging.getLogger("studip_fuse.status").log(level, " ".join(["%s"] * len(args)), *args)
+
+
 def fuse_exit():
     from fuse import _libfuse, c_void_p
 
@@ -120,6 +125,7 @@ class FUSEView(object):
                 log_ops.debug('<- %s %s', op, self.saferepr(ret))
 
     def init(self, path):
+        log_status("INITIALIZING", args=self.args)
         log.info("Mounting at %s (uid=%s, gid=%s, pid=%s, python pid=%s)", path, *fuse_get_context(),
                  os.getpid())
 
@@ -140,9 +146,11 @@ class FUSEView(object):
         self.api_thread.start()
         log.debug("HTTP API running")
 
+        log_status("READY", args=self.args)
         log.info("Mounting complete")
 
     def destroy(self, path):
+        log_status("STOPPING", args=self.args)
         log.info("Unmounting from %s (uid=%s, gid=%s, pid=%s, python pid=%s)", path, *fuse_get_context(),
                  os.getpid())
 

--- a/studip_fuse/__main__/logging.yaml
+++ b/studip_fuse/__main__/logging.yaml
@@ -17,9 +17,15 @@ handlers:
 
   file:
     class: logging.handlers.WatchedFileHandler
-    # handlers.file.filename will be inferred automatically to user_cache_dir/studip-log.txt
+    # handlers.file.filename will be inferred automatically to user_data_dir/studip-log.txt
     # filename: /tmp/studip_fuse.log
     formatter: simple
+
+  status:
+    class: logging.handlers.WatchedFileHandler
+    # handlers.file.filename will be inferred automatically to user_data_dir/studip-status.txt
+    # filename: /tmp/studip_fuse_status.log
+    formatter: console
 
   console:
     class: logging.StreamHandler
@@ -49,6 +55,10 @@ loggers:
 
   studip_api.model:
     level: INFO
+
+  studip_fuse.status:
+    handlers: [status]
+    propagate: False
 
   studip_fuse.stdout:
     handlers: [syslog, file]


### PR DESCRIPTION
Fixes #5, use `tail` and `grep` to wait for completed startup.

The result with the default logger configuration is:
```
$ cat .local/share/Stud.IP-Fuse/studip-status.txt
STARTING 0 0 -1109673712 9571 muster12 /home/muster/Stud.IP
INITIALIZING 0 0 0 9578 muster12 /home/muster/Stud.IP
READY 0 0 0 9578 muster12 /home/muster/Stud.IP
STOPPING 0 0 0 9578 muster12 /home/muster/Stud.IP
TERMINATED 0 0 0 9578 muster12 /home/muster/Stud.IP
...
```

The format is `status fuse_get_context_uid fuse_get_context_gid fuse_get_context_pid os_process_id username mountpath`.
So, to wait for successfull startup use `grep -q READY <(tail -f ~/.local/share/Stud.IP-Fuse/studip-status.txt)` (see [here](https://stackoverflow.com/a/6456103/805569) for more details on the `-q` and timeouts) and use `mountpoint /home/muster/Stud.IP` to verify the mount afterwards.