### PR TITLE
Fix incompatability with attrs 19.2.0

### DIFF
--- a/studip_fuse/avfs/virtual_path.py
+++ b/studip_fuse/avfs/virtual_path.py
@@ -28,9 +28,9 @@ def get_format_str_fields(format_segment) -> Set[FormatToken]:
 @attr.s(frozen=True, str=False)
 class VirtualPath(ABC):
     parent = attr.ib()  # type: Optional['VirtualPath']
-    path_segments = attr.ib(convert=freeze)  # type: Tuple[Union[str, FormatToken]]
-    known_data = attr.ib(convert=freeze)  # type: Dict[DataField, Any]
-    next_path_segments = attr.ib(convert=freeze)  # type: Tuple[Union[str, FormatToken]]
+    path_segments = attr.ib(converter=freeze)  # type: Tuple[Union[str, FormatToken]]
+    known_data = attr.ib(converter=freeze)  # type: Dict[DataField, Any]
+    next_path_segments = attr.ib(converter=freeze)  # type: Tuple[Union[str, FormatToken]]
 
     # __init__  ########################################################################################################
 


### PR DESCRIPTION
The `attr.ib(convert=callable)` option was deprecated in attrs 17.4 and removed
with version 19.2 in favor of `attr.ib(converter=callable)`.

This will fix the `TypeError: attrib() got an unexpected keyword argument 'convert'` error on newer distributions like ArchLinux, Ubuntu 20.04 and the current Debian Testing, which ship the newest python:attrs version 19.3